### PR TITLE
Remove secondary color from theme

### DIFF
--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -12,6 +12,9 @@ $-button-border-width: 2px;
     --button-color-filled-text: #{map.get($colors, 'text-light')};
     --button-color-quiet-background-hover: #{rgba(map.get($colors, 'gray-100'), 0.3)};
     --button-color-quiet-background-active: #{rgba(map.get($colors, 'gray-100'), 0.5)};
+    --button-color-secondary: #{map.get($colors, 'gray-600')};
+    --button-color-secondary-hover: #{map.get($colors, 'gray-700')};
+    --button-color-secondary-active: #{map.get($colors, 'gray-800')};
   }
 
   @include utils.theme('dark') {
@@ -20,6 +23,9 @@ $-button-border-width: 2px;
     --button-color-filled-text: #{map.get($colors, 'text-dark')};
     --button-color-quiet-background-hover: #{rgba(map.get($colors, 'gray-100'), 0.1)};
     --button-color-quiet-background-active: #{rgba(map.get($colors, 'gray-100'), 0.2)};
+    --button-color-secondary: #{map.get($colors, 'gray-600')};
+    --button-color-secondary-hover: #{map.get($colors, 'gray-500')};
+    --button-color-secondary-active: #{map.get($colors, 'gray-400')};
   }
 
   @include utils.control;
@@ -62,15 +68,21 @@ $-button-border-width: 2px;
 
     @each $variant in $-color-variants {
       &.button--#{$variant} {
-        background-color: var(--theme-color-#{$variant});
+        background-color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
 
         &:hover,
         &:focus {
-          background-color: var(--theme-color-#{$variant}-hover);
+          background-color: var(
+            --button-color-#{$variant}-hover,
+            var(--theme-color-#{$variant}-hover)
+          );
         }
 
         &:active {
-          background-color: var(--theme-color-#{$variant}-active);
+          background-color: var(
+            --button-color-#{$variant}-active,
+            var(--theme-color-#{$variant}-active)
+          );
         }
 
         &.button--disabled {
@@ -83,18 +95,21 @@ $-button-border-width: 2px;
   &--ghost {
     @each $variant in $-color-variants {
       &.button--#{$variant} {
-        border-color: var(--theme-color-#{$variant});
-        color: var(--theme-color-#{$variant});
+        border-color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
+        color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
 
         &:hover,
         &:focus {
-          background-color: var(--theme-color-#{$variant});
+          background-color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
           border-color: transparent;
           color: var(--button-color-filled-text);
         }
 
         &:active {
-          background-color: var(--theme-color-#{$variant}-active);
+          background-color: var(
+            --button-color-#{$variant}-active,
+            var(--theme-color-#{$variant}-active)
+          );
           border-color: transparent;
           color: var(--button-color-filled-text);
         }
@@ -111,12 +126,12 @@ $-button-border-width: 2px;
   &--quiet {
     @each $variant in $-color-variants {
       &.button--#{$variant} {
-        color: var(--theme-color-#{$variant});
+        color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
 
         &:hover,
         &:focus {
           background-color: var(--button-color-quiet-background-hover);
-          color: var(--theme-color-#{$variant}-hover);
+          color: var(--button-color-#{$variant}-hover, var(--theme-color-#{$variant}-hover));
         }
 
         &:active {
@@ -145,10 +160,10 @@ $-button-border-width: 2px;
 
     @each $variant in $-color-variants {
       &.button--#{$variant} {
-        color: var(--theme-color-#{$variant});
+        color: var(--button-color-#{$variant}, var(--theme-color-#{$variant}));
 
         &:active {
-          color: var(--theme-color-#{$variant}-active);
+          color: var(--button-color-#{$variant}-active, var(--theme-color-#{$variant}-active));
         }
 
         &.button--disabled {

--- a/src/styles/utils/themes/_dark.scss
+++ b/src/styles/utils/themes/_dark.scss
@@ -34,7 +34,6 @@ $-main-colors: (
   'dark': map.get($-pallete, 'lead'),
   'accent': map.get($-pallete, 'bleuchatel-blue'),
   'primary': map.get($-pallete, 'bleuchatel-blue'),
-  'secondary': map.get($-pallete, 'wild-dove'),
   'negative': map.get($-pallete, 'khmer-curry'),
 );
 
@@ -42,7 +41,6 @@ $-base-colors: functions.map-collect(
   $-main-colors,
   -derive-colors('accent', map.get($-main-colors, 'accent')),
   -derive-colors('primary', map.get($-main-colors, 'primary')),
-  -derive-colors('secondary', map.get($-main-colors, 'secondary')),
   -derive-colors('negative', map.get($-main-colors, 'negative')),
   -derive-colors('blue', map.get($-pallete, 'bleuchatel-blue')),
   -derive-colors('red', map.get($-pallete, 'khmer-curry')),
@@ -59,8 +57,6 @@ $-colors: map.merge(
     'focus-ring': map.get($-base-colors, 'accent-500'),
     'primary-hover': map.get($-base-colors, 'primary-500'),
     'primary-active': map.get($-base-colors, 'primary-400'),
-    'secondary-hover': map.get($-base-colors, 'secondary-500'),
-    'secondary-active': map.get($-base-colors, 'secondary-400'),
     'negative-hover': map.get($-base-colors, 'negative-500'),
     'negative-active': map.get($-base-colors, 'negative-400'),
   )

--- a/src/styles/utils/themes/_light.scss
+++ b/src/styles/utils/themes/_light.scss
@@ -34,7 +34,6 @@ $-main-colors: (
   'dark': map.get($-pallete, 'lead'),
   'accent': map.get($-pallete, 'blue-ruin'),
   'primary': map.get($-pallete, 'blue-ruin'),
-  'secondary': map.get($-pallete, 'welded-iron'),
   'negative': map.get($-pallete, 'bento-box'),
 );
 
@@ -42,7 +41,6 @@ $-base-colors: functions.map-collect(
   $-main-colors,
   -derive-colors('accent', map.get($-main-colors, 'accent')),
   -derive-colors('primary', map.get($-main-colors, 'primary')),
-  -derive-colors('secondary', map.get($-main-colors, 'secondary')),
   -derive-colors('negative', map.get($-main-colors, 'negative')),
   -derive-colors('blue', map.get($-pallete, 'blue-ruin')),
   -derive-colors('red', map.get($-pallete, 'bento-box')),
@@ -59,8 +57,6 @@ $-colors: map.merge(
     'focus-ring': map.get($-base-colors, 'accent-500'),
     'primary-hover': map.get($-base-colors, 'primary-700'),
     'primary-active': map.get($-base-colors, 'primary-800'),
-    'secondary-hover': map.get($-base-colors, 'secondary-700'),
-    'secondary-active': map.get($-base-colors, 'secondary-800'),
     'negative-hover': map.get($-base-colors, 'negative-700'),
     'negative-active': map.get($-base-colors, 'negative-800'),
   )


### PR DESCRIPTION
secondary color is only used for the button so it should be used only as a button variant